### PR TITLE
Atribute Value Trim to 4K

### DIFF
--- a/src/main/java/com/newrelic/infra/unix/UnixAgentConstants.java
+++ b/src/main/java/com/newrelic/infra/unix/UnixAgentConstants.java
@@ -26,7 +26,7 @@ public final class UnixAgentConstants {
 	public static final String kEventTypePrefix = "unixMonitor";
 	public static final char   kMetricTreeDivider='.';
 	public static final String kCommandMetricName = "command";
-	public static final int    kInsightsAttributeSize = 4096;
+	public static final int    kInsightsAttributeSize = 4092;
 	public static final String kInstanceMetricName = "instance";	
 	public static final String kJavaClassMetricName = "javaclass";
 	public static final String KAOSMetricName = "osName";


### PR DESCRIPTION
Attribute length trim to 4096 was allowing for 4098 or larger attributes
and the NRIntegrationError was logging errors in Insights with attribute
value too long. Reduced the constant from 4096 to 4092 and it works.