### PR TITLE
forward more data of 'df' command to Newrelic in mac agent

### DIFF
--- a/config/plugin-commands-osx.json
+++ b/config/plugin-commands-osx.json
@@ -10,44 +10,44 @@
 			"eventType": "Disk",
 			"command": "df -k -T nocdfs,devfs,hsfs,iso9660,nfs",
 			"mappings": [{
-				"expression": "\\s*(\\S+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)%.*",
-				"metrics": ["expression": "\\s*(\\S+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)%\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)%\\s+(\\S+).*",
-                                "metrics": [
-                                        {
-                                                "name": "DISK_NAME"
-                                        },
-                                        {
-                                                "name": "Total",
-                                                "type": "NORMAL"
-                                        },
-                                        {
-                                                "name": "Used",
-                                                "type": "NORMAL"
-                                        },
-                                        {
-                                                "name": "Free",
-                                                "type": "NORMAL"
-                                        },
-                                        {
-                                                "name": "Percent Used",
-                                                "type": "NORMAL"
-                                        },
-                                        {
-                                                "name": "Is Used",
-                                                "type": "NORMAL"
-                                        },
-                                        {
-                                                "name": "Ifree",
-                                                "type": "NORMAL"
-                                        },
-                                        {
-                                                "name": "%ISUSED",
-                                                "type": "NORMAL"
-                                        },
-                                        {
-                                                "name": "Mounted On",
-                                                "type": "NORMAL"
-                                        }
+				"expression": "\\s*(\\S+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)%\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)%\\s+(\\S+).*",
+				"metrics": [
+				  {
+						"name": "DISK_NAME"
+					},
+					{
+						"name": "Total",
+						"type": "NORMAL"
+					},
+					{
+						"name": "Used",
+						"type": "NORMAL"
+					},
+					{
+						"name": "Free",
+						"type": "NORMAL"
+					},
+					{
+						"name": "Percent Used",
+						"type": "NORMAL"
+					},
+					{
+						"name": "Is Used",
+						"type": "NORMAL"
+					},
+					{
+						"name": "Ifree",
+						"type": "NORMAL"
+					},
+					{
+						"name": "%ISUSED",
+						"type": "NORMAL"
+					},
+					{
+						"name": "Mounted On",
+						"type": "NORMAL"
+					}
+					
 				]
 			}]
 		},

--- a/config/plugin-commands-osx.json
+++ b/config/plugin-commands-osx.json
@@ -11,25 +11,43 @@
 			"command": "df -k -T nocdfs,devfs,hsfs,iso9660,nfs",
 			"mappings": [{
 				"expression": "\\s*(\\S+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)%.*",
-				"metrics": [{
-						"name": "DISK_NAME"
-					},
-					{
-						"name": "Total",
-						"type": "NORMAL"
-					},
-					{
-						"name": "Used",
-						"type": "NORMAL"
-					},
-					{
-						"name": "Free",
-						"type": "NORMAL"
-					},
-					{
-						"name": "Percent Used",
-						"type": "NORMAL"
-					}
+				"metrics": ["expression": "\\s*(\\S+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)%\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)%\\s+(\\S+).*",
+                                "metrics": [
+                                        {
+                                                "name": "DISK_NAME"
+                                        },
+                                        {
+                                                "name": "Total",
+                                                "type": "NORMAL"
+                                        },
+                                        {
+                                                "name": "Used",
+                                                "type": "NORMAL"
+                                        },
+                                        {
+                                                "name": "Free",
+                                                "type": "NORMAL"
+                                        },
+                                        {
+                                                "name": "Percent Used",
+                                                "type": "NORMAL"
+                                        },
+                                        {
+                                                "name": "Is Used",
+                                                "type": "NORMAL"
+                                        },
+                                        {
+                                                "name": "Ifree",
+                                                "type": "NORMAL"
+                                        },
+                                        {
+                                                "name": "%ISUSED",
+                                                "type": "NORMAL"
+                                        },
+                                        {
+                                                "name": "Mounted On",
+                                                "type": "NORMAL"
+                                        }
 				]
 			}]
 		},


### PR DESCRIPTION
For mac machines:
sometimes we would like to monitor a mount point, but current agent configuration only forwards the first 5 items of 'df' to Datacenter. 
this change can transfer all data of 'df' command list to data center.